### PR TITLE
Update alto.ts to be ESM compatible

### DIFF
--- a/src/instances/alto.ts
+++ b/src/instances/alto.ts
@@ -4,7 +4,6 @@ import { execa } from '../processes/execa.js'
 import { toArgs } from '../utils.js'
 
 import { fileURLToPath } from 'url';
-import { dirname, resolve as pathResolve } from 'path';
 
 export type AltoParameters = {
   /**
@@ -254,9 +253,8 @@ export const alto = defineInstance((parameters?: AltoParameters) => {
     name,
     port: args.port ?? 3000,
     async start({ port = args.port ?? 3000 }, options) {
-      const __filename = fileURLToPath(import.meta.url);
-      const __dirname = dirname(__filename);
-      const altoCliPath = pathResolve(__dirname, '../../../@pimlico/alto/esm/cli/alto.js');
+      const altoModuleUrl = await import.meta.resolve('@pimlico/alto/esm/cli/alto.js');
+      const altoCliPath = fileURLToPath(altoModuleUrl);
       const binary = ['node', altoCliPath];
 
       await process.start(($) => $`${binary} ${toArgs({ port, ...args })}`, {


### PR DESCRIPTION
We ran into an issue where this not compatible with our codebase due to using require.resolve(). 

To be more ESM compatible, this is the workaround we used to make things work. I'm open to other solutions if they make a better fit, but this is a working solution.