### PR TITLE
ci: harden workflows and supply chain

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,10 +5,10 @@ runs:
   using: 'composite'
   steps:
     - name: Set up pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '24.5'
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: 'monthly'
+      interval: monthly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      production:
+        dependency-type: production
+      development:
+        dependency-type: development

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -11,7 +13,8 @@ jobs:
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml
-    secrets: inherit
+    secrets:
+      VITE_FORK_URL: ${{ secrets.VITE_FORK_URL }}
 
   changesets:
     name: Changesets
@@ -24,14 +27,16 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
       - name: PR or publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           title: 'chore: version packages'
           commit: 'chore: version packages'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,13 +1,19 @@
 name: Prerelease
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -11,4 +13,5 @@ jobs:
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml
-    secrets: inherit
+    secrets:
+      VITE_FORK_URL: ${{ secrets.VITE_FORK_URL }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,16 +1,25 @@
 name: Verify
 on:
   workflow_call:
+    secrets:
+      VITE_FORK_URL:
+        required: false
   workflow_dispatch:
+
+permissions: {}
 
 jobs:
   checks:
     name: Checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
@@ -26,19 +35,23 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEMPO_VERSION: v1.5.0
+    permissions:
+      contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
       - name: Set up Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
 
       - name: Cache Tempo binary
         id: cache-tempo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.local/bin/tempo
           key: tempo-${{ env.TEMPO_VERSION }}-${{ runner.os }}-${{ runner.arch }}
@@ -49,8 +62,11 @@ jobs:
           TARGET="x86_64-unknown-linux-gnu"
           ARCHIVE="tempo-${TEMPO_VERSION}-${TARGET}.tar.gz"
           URL="https://github.com/tempoxyz/tempo/releases/download/${TEMPO_VERSION}/${ARCHIVE}"
+          EXPECTED_SHA="b97bf1970cdfa7b7bb017de680126686bda5a3f529c6e90cbd26973e01d2ca55"
           mkdir -p ~/.local/bin
-          curl -sSL "$URL" | tar xz -C ~/.local/bin --strip-components=0 "tempo-${TEMPO_VERSION}-${TARGET}"
+          curl -sSL "$URL" -o "/tmp/${ARCHIVE}"
+          echo "${EXPECTED_SHA}  /tmp/${ARCHIVE}" | sha256sum -c -
+          tar xzf "/tmp/${ARCHIVE}" -C ~/.local/bin --strip-components=0 "tempo-${TEMPO_VERSION}-${TARGET}"
           mv ~/.local/bin/tempo-${TEMPO_VERSION}-${TARGET} ~/.local/bin/tempo
           chmod +x ~/.local/bin/tempo
 
@@ -58,7 +74,7 @@ jobs:
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
 
       - name: Run tests
         run: pnpm test --bail=1

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "execa": "^9.1.0",
     "get-port": "^7.1.0",
     "http-proxy": "^1.18.1",
-    "tar": "7.2.0"
+    "tar": "^7.5.11"
   },
   "peerDependencies": {
     "@pimlico/alto": "*",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+strictDepBuilds: true
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
+minimumReleaseAge: 1440
+
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
Pin GitHub Actions to commit SHAs, restrict workflow permissions, add npm dependabot config, verify Tempo binary checksum, and enable pnpm strict dep builds.

Co-Authored-By: grandizzy <38490174+grandizzy@users.noreply.github.com>

Prompted by: george