### PR TITLE
Migrate process wrapper to tinyexec

### DIFF
--- a/.changeset/yellow-rockets-jam.md
+++ b/.changeset/yellow-rockets-jam.md
@@ -1,0 +1,5 @@
+---
+"prool": patch
+---
+
+Migrated the process wrapper from execa to tinyexec while preserving the tagged-template command API.

--- a/package.json
+++ b/package.json
@@ -51,12 +51,13 @@
     }
   },
   "dependencies": {
+    "args-tokenizer": "^0.3.0",
     "change-case": "5.4.4",
     "eventemitter3": "^5.0.1",
-    "execa": "^9.1.0",
     "get-port": "^7.1.0",
     "http-proxy": "^1.18.1",
-    "tar": "7.2.0"
+    "tar": "7.2.0",
+    "tinyexec": "^1.0.2"
   },
   "peerDependencies": {
     "@pimlico/alto": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,15 @@ importers:
 
   .:
     dependencies:
+      args-tokenizer:
+        specifier: ^0.3.0
+        version: 0.3.0
       change-case:
         specifier: 5.4.4
         version: 5.4.4
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
-      execa:
-        specifier: ^9.1.0
-        version: 9.1.0
       get-port:
         specifier: ^7.1.0
         version: 7.1.0
@@ -26,6 +26,9 @@ importers:
       tar:
         specifier: 7.2.0
         version: 7.2.0
+      tinyexec:
+        specifier: ^1.0.2
+        version: 1.0.2
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.3.8
@@ -860,9 +863,6 @@ packages:
   '@scure/bip39@1.5.4':
     resolution: {integrity: sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==}
 
-  '@sec-ant/readable-stream@0.4.1':
-    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
-
   '@sentry-internal/tracing@7.116.0':
     resolution: {integrity: sha512-y5ppEmoOlfr77c/HqsEXR72092qmGYS4QE5gSz5UZFn9CiinEwGfEorcg2xIrrCuU7Ry/ZU2VLz9q3xd04drRA==}
     engines: {node: '>=8'}
@@ -886,10 +886,6 @@ packages:
   '@sentry/utils@7.116.0':
     resolution: {integrity: sha512-Vn9fcvwTq91wJvCd7WTMWozimqMi+dEZ3ie3EICELC2diONcN16ADFdzn65CQQbYwmUzRjN9EjDN2k41pKZWhQ==}
     engines: {node: '>=8'}
-
-  '@sindresorhus/merge-streams@4.0.0':
-    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
-    engines: {node: '>=18'}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -1070,6 +1066,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  args-tokenizer@0.3.0:
+    resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -1389,10 +1388,6 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  execa@9.1.0:
-    resolution: {integrity: sha512-lSgHc4Elo2m6bUDhc3Hl/VxvUDJdQWI40RZ4KMY9bKRc+hgMOT7II/JjbNDhI8VnMtrCb7U/fhpJIkLORZozWw==}
-    engines: {node: '>=18'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1452,10 +1447,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  figures@6.1.0:
-    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
-    engines: {node: '>=18'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1517,10 +1508,6 @@ packages:
     resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
     engines: {node: '>=16'}
 
-  get-stream@9.0.1:
-    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
-    engines: {node: '>=18'}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1558,10 +1545,6 @@ packages:
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
-
-  human-signals@7.0.0:
-    resolution: {integrity: sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==}
-    engines: {node: '>=18.18.0'}
 
   iconv-lite@0.7.0:
     resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
@@ -1613,25 +1596,13 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
-
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
-  is-stream@4.0.1:
-    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
-    engines: {node: '>=18'}
-
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
-
-  is-unicode-supported@2.0.0:
-    resolution: {integrity: sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==}
-    engines: {node: '>=18'}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -1837,10 +1808,6 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -1891,10 +1858,6 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
-  parse-ms@4.0.0:
-    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
-    engines: {node: '>=18'}
-
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1902,10 +1865,6 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -1972,10 +1931,6 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-
-  pretty-ms@9.0.0:
-    resolution: {integrity: sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==}
-    engines: {node: '>=18'}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -2235,10 +2190,6 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-
-  strip-final-newline@4.0.0:
-    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
-    engines: {node: '>=18'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2524,10 +2475,6 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yoctocolors@2.0.2:
-    resolution: {integrity: sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==}
-    engines: {node: '>=18'}
 
   zile@0.0.13:
     resolution: {integrity: sha512-a6F5jiKqSd12kf/n1bVIjLpP5FbKr2g1sgdfysMvT+cpyjz0uN6ChY0HX93+7d0OkFa7UX+eiqBJG4ZPVlcIww==}
@@ -3406,8 +3353,6 @@ snapshots:
       '@noble/hashes': 1.7.1
       '@scure/base': 1.2.4
 
-  '@sec-ant/readable-stream@0.4.1': {}
-
   '@sentry-internal/tracing@7.116.0':
     dependencies:
       '@sentry/core': 7.116.0
@@ -3439,8 +3384,6 @@ snapshots:
   '@sentry/utils@7.116.0':
     dependencies:
       '@sentry/types': 7.116.0
-
-  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -3641,6 +3584,8 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  args-tokenizer@0.3.0: {}
 
   array-union@2.1.0: {}
 
@@ -3961,21 +3906,6 @@ snapshots:
 
   events@3.3.0: {}
 
-  execa@9.1.0:
-    dependencies:
-      '@sindresorhus/merge-streams': 4.0.0
-      cross-spawn: 7.0.6
-      figures: 6.1.0
-      get-stream: 9.0.1
-      human-signals: 7.0.0
-      is-plain-obj: 4.1.0
-      is-stream: 4.0.1
-      npm-run-path: 5.3.0
-      pretty-ms: 9.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 4.0.0
-      yoctocolors: 2.0.2
-
   expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
@@ -4047,10 +3977,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  figures@6.1.0:
-    dependencies:
-      is-unicode-supported: 2.0.0
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -4100,11 +4026,6 @@ snapshots:
 
   get-port@7.1.0: {}
 
-  get-stream@9.0.1:
-    dependencies:
-      '@sec-ant/readable-stream': 0.4.1
-      is-stream: 4.0.1
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -4147,8 +4068,6 @@ snapshots:
       - debug
 
   human-id@4.1.3: {}
-
-  human-signals@7.0.0: {}
 
   iconv-lite@0.7.0:
     dependencies:
@@ -4206,17 +4125,11 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-plain-obj@4.1.0: {}
-
   is-stream@2.0.1: {}
-
-  is-stream@4.0.1: {}
 
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
-
-  is-unicode-supported@2.0.0: {}
 
   is-windows@1.0.2: {}
 
@@ -4407,10 +4320,6 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
-  npm-run-path@5.3.0:
-    dependencies:
-      path-key: 4.0.0
-
   obug@2.1.1: {}
 
   on-exit-leak-free@2.1.2: {}
@@ -4463,13 +4372,9 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  parse-ms@4.0.0: {}
-
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
-
-  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -4560,10 +4465,6 @@ snapshots:
       source-map-js: 1.2.1
 
   prettier@2.8.8: {}
-
-  pretty-ms@9.0.0:
-    dependencies:
-      parse-ms: 4.0.0
 
   process-nextick-args@2.0.1: {}
 
@@ -4861,8 +4762,6 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-final-newline@4.0.0: {}
-
   strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
@@ -5129,8 +5028,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yoctocolors@2.0.2: {}
 
   zile@0.0.13(typescript@5.9.3):
     dependencies:

--- a/src/processes/execa.ts
+++ b/src/processes/execa.ts
@@ -1,9 +1,14 @@
+import type { ChildProcess, SpawnOptions } from 'node:child_process'
 import type { SignalConstants } from 'node:os'
-import { execa as exec, type ResultPromise } from 'execa'
+import { tokenizeArgs } from 'args-tokenizer'
+import { x as exec, type Result } from 'tinyexec'
 import type * as Instance from '../Instance.js'
 import { stripColors } from '../internal/utils.js'
 
-export type Process_internal = ResultPromise<{ cleanup: true; reject: false }>
+export type Process_internal = ChildProcess & {
+  stderr: NonNullable<ChildProcess['stderr']>
+  stdout: NonNullable<ChildProcess['stdout']>
+}
 
 export type ExecaStartOptions =
   Instance.define.InstanceStartOptions_internal & {
@@ -20,43 +25,104 @@ export type Process = {
   }
   name: string
   start(
-    command: (x: typeof exec) => void,
+    command: (x: TinyexecTag) => Result,
     options: ExecaStartOptions,
   ): Promise<void>
   stop(signal?: keyof SignalConstants | number): Promise<void>
+}
+
+type TinyexecTagOptions = Omit<SpawnOptions, 'env'> & {
+  env?: NodeJS.ProcessEnv | undefined
+}
+
+type TinyexecTag = {
+  (strings: TemplateStringsArray, ...values: readonly unknown[]): Result
+  (options: TinyexecTagOptions): TinyexecTag
+}
+
+function toCommandArgs(
+  strings: TemplateStringsArray,
+  values: readonly unknown[],
+) {
+  const args: string[] = []
+
+  for (let i = 0; i < strings.length; i++) {
+    const string = strings[i]
+    if (string) args.push(...tokenizeArgs(string, { loose: true }))
+
+    const value = values[i]
+    if (value === undefined || value === null) continue
+
+    if (Array.isArray(value)) {
+      args.push(...value.map((item) => item.toString()))
+      continue
+    }
+
+    args.push(value.toString())
+  }
+
+  const [command, ...commandArgs] = args
+  if (!command) throw new Error('Missing command')
+  return { args: commandArgs, command }
+}
+
+function isTemplateStringsArray(value: unknown): value is TemplateStringsArray {
+  return Array.isArray(value) && 'raw' in value
+}
+
+function createTinyexecTag(options: TinyexecTagOptions = {}): TinyexecTag {
+  return ((stringsOrOptions, ...values) => {
+    if (!isTemplateStringsArray(stringsOrOptions)) {
+      return createTinyexecTag({ ...options, ...stringsOrOptions })
+    }
+
+    const { args, command } = toCommandArgs(stringsOrOptions, values)
+    const { env, ...nodeOptions } = options
+    return exec(command, args, {
+      nodeOptions: {
+        ...nodeOptions,
+        ...(env ? { env: { ...process.env, ...env } } : {}),
+      },
+      throwOnError: false,
+    })
+  }) as TinyexecTag
 }
 
 export function execa(parameters: execa.Parameters): execa.ReturnType {
   const { name } = parameters
 
   const errorMessages: string[] = []
-  let process: Process_internal
+  let process: Process_internal | undefined
+  let result: Result | undefined
 
   async function stop(signal?: keyof SignalConstants | number) {
-    const killed = process.kill(signal)
+    const childProcess = process
+    if (!childProcess) return
+    const killed = childProcess.kill(signal)
     if (!killed) return
-    return new Promise((resolve) => process.on('close', resolve))
+    return new Promise((resolve) => childProcess.on('close', resolve))
   }
 
   return {
     _internal: {
       get process() {
-        return process
+        return process as Process_internal
       },
     },
     name,
     start(command, { emitter, resolver, status }) {
       const { promise, resolve, reject } = Promise.withResolvers<void>()
 
-      process = command(
-        exec({
-          cleanup: true,
-          reject: false,
-        }) as any,
-      ) as unknown as Process_internal
+      result = command(createTinyexecTag())
+      const childProcess = result.process
+      if (!childProcess?.stdout || !childProcess.stderr)
+        throw new Error(`Failed to start process "${name}"`)
+
+      process = childProcess as Process_internal
+      const currentProcess = process
 
       resolver({
-        process,
+        process: currentProcess,
         async reject(data) {
           await stop()
           reject(
@@ -69,12 +135,12 @@ export function execa(parameters: execa.Parameters): execa.ReturnType {
         },
       })
 
-      process.stdout.on('data', (data) => {
+      currentProcess.stdout.on('data', (data) => {
         const message = stripColors(data.toString())
         emitter.emit('message', message)
         emitter.emit('stdout', message)
       })
-      process.stderr.on('data', async (data) => {
+      currentProcess.stderr.on('data', async (data) => {
         const message = stripColors(data.toString())
 
         errorMessages.push(message)
@@ -83,30 +149,34 @@ export function execa(parameters: execa.Parameters): execa.ReturnType {
         emitter.emit('message', message)
         emitter.emit('stderr', message)
       })
-      process.on('close', () => process.removeAllListeners())
-      process.on('exit', (code, signal) => {
+      currentProcess.on('error', (error) => {
+        reject(new Error(`Failed to start process "${name}": ${error.message}`))
+      })
+      currentProcess.on('close', () => currentProcess.removeAllListeners())
+      currentProcess.on('exit', (code, signal) => {
         emitter.emit('exit', code, signal)
 
-        if (!code) {
-          process.removeAllListeners()
-          if (status === 'starting')
-            reject(
-              new Error(
-                `Failed to start process "${name}": ${
-                  errorMessages.length > 0
-                    ? `\n\n${errorMessages.join('\n')}`
-                    : 'exited'
-                }`,
-              ),
-            )
+        if (code !== 0 || status === 'starting') {
+          currentProcess.removeAllListeners()
+          reject(
+            new Error(
+              `Failed to start process "${name}": ${
+                errorMessages.length > 0
+                  ? `\n\n${errorMessages.join('\n')}`
+                  : 'exited'
+              }`,
+            ),
+          )
         }
       })
 
       return promise
     },
     async stop() {
+      if (!process) return
       process.removeAllListeners()
       await stop()
+      result = undefined
     },
   }
 }


### PR DESCRIPTION
## Summary
- Replaces `execa` with `tinyexec` for the internal process wrapper.
- Keeps the existing tagged-template callback shape used by instance start commands.
- Uses `args-tokenizer` for command string tokenization and preserves array interpolation support.
- Adds a changeset for a patch release.

Fixes #34.

## Verification
- `pnpm install --lockfile-only`
- `pnpm install --ignore-scripts`
- `pnpm exec tsc --noEmit`
- `pnpm exec biome check src/processes/execa.ts package.json .changeset/yellow-rockets-jam.md`
- `git diff --check`

## Note
- `pnpm exec vitest src/processes/execa.test.ts --run` was attempted locally. The environment is missing the `anvil` binary, so the tests that start an Anvil process fail with: `'anvil' is not recognized as an internal or external command`.