### PR TITLE
Ignore silent option for anvil instances

### DIFF
--- a/src/instances/anvil.test.ts
+++ b/src/instances/anvil.test.ts
@@ -1,6 +1,8 @@
 import { Instance } from 'prool'
 import { afterEach, expect, test } from 'vitest'
 
+import { anvil } from './anvil.js'
+
 const instances: Instance.Instance[] = []
 const timestamp = 1717114065
 
@@ -38,6 +40,14 @@ test('default', async () => {
   expect(messages.join('')).toBeDefined()
   expect(stdouts.join('')).toBeDefined()
   expect(instance.messages.get()).toMatchInlineSnapshot('[]')
+})
+
+test('behavior: ignores silent option', () => {
+  const instance = anvil({
+    silent: true,
+  } as anvil.Parameters & { silent: boolean })
+
+  expect(instance._internal.args).not.toHaveProperty('silent')
 })
 
 test('behavior: instance errored (duplicate ports)', async () => {

--- a/src/instances/anvil.ts
+++ b/src/instances/anvil.ts
@@ -14,7 +14,11 @@ import { execa } from '../processes/execa.js'
  * ```
  */
 export const anvil = Instance.define((parameters?: anvil.Parameters) => {
-  const { binary = 'anvil', ...args } = parameters || {}
+  const {
+    binary = 'anvil',
+    silent: _silent,
+    ...args
+  } = (parameters as anvil.Parameters & { silent?: boolean }) || {}
 
   const name = 'anvil'
   const process = execa({ name })
@@ -267,10 +271,6 @@ export declare namespace anvil {
      * @defaultValue 5
      */
     retries?: number | undefined
-    /**
-     * Don't print anything on startup and don't print logs.
-     */
-    silent?: boolean | undefined
     /**
      * Slots in an epoch.
      */


### PR DESCRIPTION
## Summary
- stop forwarding the Anvil silent option so startup logs remain available to the readiness resolver
- remove silent from the public Anvil parameter type
- add a focused regression test that confirms silent is stripped from internal args

Fixes #80.

## Verification
- pnpm exec vitest src/instances/anvil.test.ts --run -t "ignores silent option"
- pnpm exec tsc --noEmit
- pnpm exec biome check src/instances/anvil.ts src/instances/anvil.test.ts
- git diff --check

Note: the full anvil integration test file cannot run on this Windows machine because the anvil binary is not installed in PATH; the focused regression test does not require the binary.