### PR TITLE
Add viem test client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,31 @@ await server.start()
 // "http://localhost:8545/n"
 ```
 
+#### Viem Test Client
+
+```ts
+import { Instance, Server } from 'prool'
+import { createTestClient, http } from 'viem'
+import { foundry } from 'viem/chains'
+
+const server = Server.create({
+  instance: Instance.anvil(),
+})
+await server.start()
+
+const client = createTestClient({
+  chain: foundry,
+  mode: 'anvil',
+  transport: http('http://localhost:8545/1'),
+})
+
+await client.mine({ blocks: 1 })
+```
+
+The server lazily starts the Anvil instance for `/1` when the test client sends
+its first request. To start it eagerly, request `http://localhost:8545/1/start`
+before creating the client.
+
 ### Tempo (Execution Node)
 
 #### Requirements


### PR DESCRIPTION
## Summary
- add a README example for using viem createTestClient with a prool Anvil instance
- point the viem transport at the prool instance endpoint /1
- mention that prool lazily starts the instance on first request, with /1/start available for eager startup

Fixes #28.

## Verification
- git diff --check
- rg -n "Viem Test Client|createTestClient|http\\('http://localhost:8545/1'\\)|client.mine" README.md

Note: biome check does not process README.md with the current repository configuration, so this README-only change was verified with diff checks and content search.