### PR TITLE
chore: add changeset for `tempo` ws and `tempoZone` private rpc

### DIFF
--- a/.changeset/tempo-ws-private-rpc.md
+++ b/.changeset/tempo-ws-private-rpc.md
@@ -1,0 +1,5 @@
+---
+"prool": patch
+---
+
+Enabled WebSocket on the `tempo` instance HTTP port and exposed the `tempoZone` private RPC endpoint on testcontainers.


### PR DESCRIPTION
Adds the missing changeset for https://github.com/wevm/prool/pull/87 so the `tempo` WS + `tempoZone` private RPC change ships in the next release.
