### PR TITLE
feat: add named vitest instances

### DIFF
--- a/.changeset/named-vitest-instances.md
+++ b/.changeset/named-vitest-instances.md
@@ -1,5 +1,5 @@
 ---
-'prool': minor
+'prool': patch
 ---
 
 Added named instances to Vitest server and pool setup with worker isolation and independent server lifecycle controls.

--- a/.changeset/named-vitest-instances.md
+++ b/.changeset/named-vitest-instances.md
@@ -1,0 +1,17 @@
+---
+'prool': minor
+---
+
+Added named instances to Vitest server and pool setup with worker isolation and independent server lifecycle controls.
+
+```ts
+import { Instance } from 'prool'
+import { Server } from 'prool/vitest'
+
+export default Server.setup({
+  instances: { l1: Instance.anvil(), l2: Instance.anvil() },
+  setup(chains, project) {
+    project.provide('chains', chains)
+  },
+})
+```

--- a/.changeset/process-startup-lifecycle.md
+++ b/.changeset/process-startup-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'prool': patch
+---
+
+Fixed IPv4 pool port allocation, process restart races, and startup rejection when a child exits before becoming ready.

--- a/README.md
+++ b/README.md
@@ -334,6 +334,14 @@ const instance_3 = await pool.start(3)
 use `Server.get` to address, reset, or restart its own instance. `Pool.setup`
 eagerly starts one direct instance per worker instead.
 
+Both helpers also accept named `instances` instead of `instance`. Each name
+gets its own isolated instance per worker. The single-instance API is unchanged.
+Concurrent tests within one worker still share that worker's instances.
+
+Both helpers clean up all named resources during teardown or failed setup.
+Eager pools wait for pending starts before cleanup. Teardown attempts every
+named resource even when another teardown fails, and reports cleanup errors.
+
 #### Config
 
 ```ts
@@ -381,6 +389,46 @@ export const rpcUrl = anvil.url
 `reset` destroys only that worker's instance, and its next request starts a
 fresh one. `restart` retains the pooled instance and endpoint.
 
+For multiple instances, pass named `instances` to start one lazy proxy per name.
+Each proxy binds to an automatically assigned port, and each pool allows up to
+`maxWorkers` instances. Definitions can also be factories that receive the
+worker's pool ID.
+
+```ts
+// test/setup.global.ts
+import { Instance } from 'prool'
+import { Server } from 'prool/vitest'
+import type { TestProject } from 'vitest/node'
+
+declare module 'vitest' {
+  export interface ProvidedContext {
+    chains: { l1: Server.Context; l2: Server.Context }
+  }
+}
+
+export default Server.setup({
+  instances: {
+    l1: Instance.anvil(),
+    l2: Instance.anvil(),
+  },
+  setup(chains, project: TestProject) {
+    project.provide('chains', chains)
+  },
+})
+```
+
+```ts
+// test/setup.ts
+import { Server } from 'prool/vitest'
+import { inject } from 'vitest'
+
+export const { l1, l2 } = Server.get(inject('chains'))
+await Promise.all([l1.reset(), l2.reset()])
+```
+
+`l1.url` and `l2.url` address separate instances for the current worker.
+Resetting or restarting one does not affect the other names or workers.
+
 #### Eager Pool
 
 ```ts
@@ -410,6 +458,44 @@ import { Pool } from 'prool/vitest'
 import { inject } from 'vitest'
 
 export const rpcUrl = Pool.get(inject('rpcUrls'))
+```
+
+For multiple instances, pass named `instances`. The setup callback receives an
+array of named records, ordered by worker ID. Provide serializable values such
+as URLs; `Pool.get` selects the current worker's record.
+
+```ts
+// test/setup.global.ts
+import { Instance } from 'prool'
+import { Pool } from 'prool/vitest'
+import type { TestProject } from 'vitest/node'
+
+declare module 'vitest' {
+  export interface ProvidedContext {
+    chainUrls: readonly { l1: string; l2: string }[]
+  }
+}
+
+export default Pool.setup({
+  instances: {
+    l1: Instance.anvil(),
+    l2: Instance.anvil(),
+  },
+  setup(instances, project: TestProject) {
+    project.provide(
+      'chainUrls',
+      instances.map(({ l1, l2 }) => ({ l1: l1.url, l2: l2.url })),
+    )
+  },
+})
+```
+
+```ts
+// test/setup.ts
+import { Pool } from 'prool/vitest'
+import { inject } from 'vitest'
+
+export const { l1, l2 } = Pool.get(inject('chainUrls'))
 ```
 
 ## Authors

--- a/src/Pool.test.ts
+++ b/src/Pool.test.ts
@@ -1,5 +1,6 @@
+import * as Net from 'node:net'
 import * as os from 'node:os'
-import getPort from 'get-port'
+import getPort, * as Ports from 'get-port'
 import { Instance, Pool, Server } from 'prool'
 import {
   afterAll,
@@ -12,6 +13,8 @@ import {
 } from 'vitest'
 
 import { altoOptions } from '../test/utils.js'
+
+vi.mock('get-port', { spy: true })
 
 let pool: ReturnType<typeof Pool.define> | undefined
 const executionServer = Server.create({
@@ -32,6 +35,53 @@ afterEach(async () => {
   } catch (err) {
     console.error(err)
   }
+})
+
+describe('start', () => {
+  test('avoids ports occupied by IPv4 listeners', async () => {
+    const occupied = Net.createServer()
+    await new Promise<void>((resolve) => occupied.listen(0, '0.0.0.0', resolve))
+    const address = occupied.address() as Net.AddressInfo
+    const { default: allocate } =
+      await vi.importActual<typeof Ports>('get-port')
+    // Model a platform where an IPv6-only ephemeral allocation overlaps IPv4.
+    const spy = vi
+      .mocked(Ports.default)
+      .mockImplementationOnce((options) =>
+        options?.host === '0.0.0.0'
+          ? allocate(options)
+          : Promise.resolve(address.port),
+      )
+    const instance = Instance.define(() => {
+      const server = Net.createServer()
+      return {
+        name: 'ipv4',
+        host: '127.0.0.1',
+        port: 0,
+        async start({ port }) {
+          await new Promise<void>((resolve, reject) => {
+            server.once('error', reject)
+            server.listen(port, '0.0.0.0', resolve)
+          })
+        },
+        async stop() {
+          await new Promise<void>((resolve, reject) =>
+            server.close((error) => (error ? reject(error) : resolve())),
+          )
+        },
+      }
+    })()
+    const pool = Pool.define({ instance })
+    try {
+      const started = await pool.start(1)
+      expect(started.status).toBe('started')
+      expect(started.port).not.toBe(address.port)
+    } finally {
+      spy.mockReset()
+      await pool.destroyAll()
+      await new Promise<void>((resolve) => occupied.close(() => resolve()))
+    }
+  })
 })
 
 test('preserves named endpoint types', async () => {

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -332,7 +332,9 @@ export function define<
           typeof parameters.instance === 'function'
             ? parameters.instance(key)
             : parameters.instance
-        const { port = await getPort() } = options
+        // An IPv6-only probe can select a port already bound by an IPv4 node.
+        const host = instance.host.includes(':') ? instance.host : '0.0.0.0'
+        const { port = await getPort({ host }) } = options
 
         const instance_ =
           instances.get(key) || (instance.create({ port }) as Instance_)

--- a/src/processes/execa.test.ts
+++ b/src/processes/execa.test.ts
@@ -1,7 +1,8 @@
+import * as NodeProcess from 'node:process'
 import { EventEmitter } from 'eventemitter3'
 import getPort from 'get-port'
-import { afterEach, expect, test } from 'vitest'
-import { execa } from './execa.js'
+import { afterEach, describe, expect, test } from 'vitest'
+import { type ExecaStartOptions, execa } from './execa.js'
 
 const processes: execa.ReturnType[] = []
 function createProcess() {
@@ -12,6 +13,53 @@ function createProcess() {
 
 afterEach(async () => {
   for (const process of processes) await process.stop().catch(() => {})
+})
+
+describe('execa', () => {
+  test.each([0, 1])('rejects exit code %s before readiness', async (code) => {
+    const process = createProcess()
+    const emitter: ExecaStartOptions['emitter'] = new EventEmitter()
+    await expect(
+      process.start(
+        ($) => $`${NodeProcess.execPath} -e ${`process.exit(${code})`}`,
+        {
+          emitter,
+          status: 'starting',
+          resolver() {},
+        },
+      ),
+    ).rejects.toThrowError('Failed to start process "foo": exited')
+  })
+
+  test('keeps a restarted process alive after a previous resolver rejects', async () => {
+    const process = createProcess()
+    const emitter: ExecaStartOptions['emitter'] = new EventEmitter()
+    const previousReject =
+      Promise.withResolvers<(data: string) => Promise<void>>()
+    const script = "process.stdout.write('ready'); setInterval(() => {}, 1000)"
+    await process.start(($) => $`${NodeProcess.execPath} -e ${script}`, {
+      emitter,
+      status: 'starting',
+      resolver({ process, reject, resolve }) {
+        previousReject.resolve(reject)
+        process.stdout.once('data', resolve)
+      },
+    })
+    await process.stop()
+    await process.start(($) => $`${NodeProcess.execPath} -e ${script}`, {
+      emitter,
+      status: 'starting',
+      resolver({ process, resolve }) {
+        process.stdout.once('data', resolve)
+      },
+    })
+
+    const current = process._internal.process
+    await (await previousReject.promise)('shutting down')
+    expect(current.killed).toBe(false)
+    expect(current.exitCode).toBeNull()
+    expect(current.signalCode).toBeNull()
+  })
 })
 
 test('default', async () => {

--- a/src/processes/execa.ts
+++ b/src/processes/execa.ts
@@ -29,14 +29,16 @@ export type Process = {
 export function execa(parameters: execa.Parameters): execa.ReturnType {
   const { name } = parameters
 
-  const errorMessages: string[] = []
   let process: Process_internal
 
-  async function stop(signal?: keyof SignalConstants | number) {
-    process.kill(signal)
+  async function stop(
+    child: Process_internal,
+    signal?: keyof SignalConstants | number,
+  ) {
+    child.kill(signal)
     // Process may have exited on its own; 'exit' will not re-fire.
-    if (process.exitCode !== null || process.signalCode !== null) return
-    return new Promise((resolve) => process.once('exit', resolve))
+    if (child.exitCode !== null || child.signalCode !== null) return
+    return new Promise((resolve) => child.once('exit', resolve))
   }
 
   return {
@@ -48,18 +50,21 @@ export function execa(parameters: execa.Parameters): execa.ReturnType {
     name,
     start(command, { emitter, resolver, status }) {
       const { promise, resolve, reject } = Promise.withResolvers<void>()
+      const errorMessages: string[] = []
 
-      process = command(
+      const child = command(
         exec({
           cleanup: true,
           reject: false,
         }) as any,
       ) as unknown as Process_internal
+      process = child
 
       resolver({
-        process,
+        process: child,
         async reject(data) {
-          await stop()
+          // Shutdown output can arrive after another process has started.
+          await stop(child)
           reject(
             new Error(`Failed to start process "${name}": ${data.toString()}`),
           )
@@ -70,12 +75,12 @@ export function execa(parameters: execa.Parameters): execa.ReturnType {
         },
       })
 
-      process.stdout.on('data', (data) => {
+      child.stdout.on('data', (data) => {
         const message = stripColors(data.toString())
         emitter.emit('message', message)
         emitter.emit('stdout', message)
       })
-      process.stderr.on('data', async (data) => {
+      child.stderr.on('data', async (data) => {
         const message = stripColors(data.toString())
 
         errorMessages.push(message)
@@ -84,30 +89,28 @@ export function execa(parameters: execa.Parameters): execa.ReturnType {
         emitter.emit('message', message)
         emitter.emit('stderr', message)
       })
-      process.on('close', () => process.removeAllListeners())
-      process.on('exit', (code, signal) => {
+      child.on('close', () => child.removeAllListeners())
+      child.on('exit', (code, signal) => {
         emitter.emit('exit', code, signal)
 
-        if (!code) {
-          process.removeAllListeners()
-          if (status === 'starting')
-            reject(
-              new Error(
-                `Failed to start process "${name}": ${
-                  errorMessages.length > 0
-                    ? `\n\n${errorMessages.join('\n')}`
-                    : 'exited'
-                }`,
-              ),
-            )
-        }
+        child.removeAllListeners()
+        if (status === 'starting')
+          reject(
+            new Error(
+              `Failed to start process "${name}": ${
+                errorMessages.length > 0
+                  ? `\n\n${errorMessages.join('\n')}`
+                  : 'exited'
+              }`,
+            ),
+          )
       })
 
       return promise
     },
     async stop() {
       process.removeAllListeners()
-      await stop()
+      await stop(process)
     },
   }
 }

--- a/src/vitest/Pool.test-d.ts
+++ b/src/vitest/Pool.test-d.ts
@@ -1,0 +1,76 @@
+import { Instance } from 'prool'
+import { Pool } from 'prool/vitest'
+import { describe, expectTypeOf, test } from 'vitest'
+
+describe('setup', () => {
+  test('preserves heterogeneous endpoints through definitions and factories', () => {
+    const metrics = Instance.define(() => ({
+      name: 'metrics',
+      host: 'localhost',
+      port: 3000,
+      endpoints: {
+        metrics: { host: 'localhost', port: 9000, protocol: 'http' as const },
+      },
+      async start() {},
+      async stop() {},
+    }))()
+    const socket = Instance.define(() => ({
+      name: 'socket',
+      host: 'localhost',
+      port: 4000,
+      endpoints: {
+        socket: { host: 'localhost', port: 9001, protocol: 'ws' as const },
+      },
+      async start() {},
+      async stop() {},
+    }))()
+    expectTypeOf<
+      Pool.setup.Instances<{
+        choice: typeof metrics | ((id: number) => typeof socket)
+      }>['choice']
+    >().toEqualTypeOf<
+      Omit<typeof metrics, 'create'> | Omit<typeof socket, 'create'>
+    >()
+    Pool.setup({
+      instances: {
+        l1: metrics,
+        l2: (id) => {
+          expectTypeOf(id).toEqualTypeOf<number>()
+          return socket
+        },
+      },
+      setup(instances, project) {
+        expectTypeOf(
+          instances[0]!.l1.endpoints.metrics.protocol,
+        ).toEqualTypeOf<'http'>()
+        expectTypeOf(
+          instances[0]!.l2.endpoints.socket.protocol,
+        ).toEqualTypeOf<'ws'>()
+        expectTypeOf(project).toEqualTypeOf<Pool.setup.Project>()
+        // @ts-expect-error Endpoints belong to their named definition.
+        instances[0]!.l1.endpoints.socket
+        // @ts-expect-error Only configured names are available.
+        instances[0]!.l3
+      },
+    })
+  })
+
+  test('rejects mixed single and named definitions', () => {
+    // @ts-expect-error Setup accepts either instance or instances.
+    Pool.setup({
+      instance: Instance.anvil(),
+      instances: { l1: Instance.anvil() },
+      setup() {},
+    })
+  })
+})
+
+describe('get', () => {
+  test('preserves named values for the worker', () => {
+    const urls = Pool.get([
+      { l1: 'http://localhost:3000', l2: 'http://localhost:4000' },
+    ] as const)
+    expectTypeOf(urls.l1).toEqualTypeOf<'http://localhost:3000'>()
+    expectTypeOf(urls.l2).toEqualTypeOf<'http://localhost:4000'>()
+  })
+})

--- a/src/vitest/Pool.test.ts
+++ b/src/vitest/Pool.test.ts
@@ -45,6 +45,121 @@ describe('poolId', () => {
 })
 
 describe('setup', () => {
+  test('starts each named instance for every worker', async () => {
+    const stopped: string[] = []
+    const definition = Instance.define((name: string) => ({
+      host: 'localhost',
+      name,
+      port: 3000,
+      async start() {},
+      async stop() {
+        stopped.push(name)
+      },
+    }))
+    const { context, project } = testProject(2)
+    const setup = Pool.setup({
+      instances: {
+        l1: (id) => definition(`l1-${id}`),
+        l2: (id) => definition(`l2-${id}`),
+      },
+      setup(instances, project) {
+        expect(instances.map(({ l1, l2 }) => [l1.name, l2.name])).toEqual([
+          ['l1-1', 'l2-1'],
+          ['l1-2', 'l2-2'],
+        ])
+        expect(
+          new Set(instances.flatMap(({ l1, l2 }) => [l1.url, l2.url])).size,
+        ).toBe(4)
+        project.provide(
+          'names',
+          instances.map(({ l1, l2 }) => ({ l1: l1.name, l2: l2.name })),
+        )
+      },
+    })
+    const teardown = await setup(project)
+    try {
+      vi.stubEnv('VITEST_POOL_ID', '2')
+      expect(
+        Pool.get(context.get('names') as readonly { l1: string; l2: string }[]),
+      ).toEqual({ l1: 'l1-2', l2: 'l2-2' })
+    } finally {
+      await teardown()
+    }
+    expect(stopped.sort()).toEqual(['l1-1', 'l1-2', 'l2-1', 'l2-2'])
+  })
+
+  test('waits for late starts before cleaning up a failed named setup', async () => {
+    const stopped: string[] = []
+    const failed = Promise.withResolvers<void>()
+    const late = Promise.withResolvers<void>()
+    const definition = Instance.define((name: string) => ({
+      host: 'localhost',
+      name,
+      port: 3000,
+      async start() {
+        if (name === 'l1-1') {
+          failed.resolve()
+          throw new Error('start failed')
+        }
+        await late.promise
+      },
+      async stop() {
+        stopped.push(name)
+      },
+    }))
+    const callback = vi.fn()
+    const setup = Pool.setup({
+      instances: {
+        l1: (id) => definition(`l1-${id}`),
+        l2: (id) => definition(`l2-${id}`),
+      },
+      setup: callback,
+    })
+    const result = setup(testProject(2).project).catch(
+      (error: unknown) => error,
+    )
+    await failed.promise
+    expect(stopped).toEqual([])
+    late.resolve()
+    expect(await result).toEqual(new Error('start failed'))
+    expect(callback).not.toHaveBeenCalled()
+    expect(stopped.sort()).toEqual(['l1-2', 'l2-1', 'l2-2'])
+  })
+
+  test.each([
+    false,
+    true,
+  ])('cleans up named pools after callback failure, stop failure: %s', async (failStop) => {
+    const stopped: string[] = []
+    const definition = Instance.define((name: string) => ({
+      host: 'localhost',
+      name,
+      port: 3000,
+      async start() {},
+      async stop() {
+        stopped.push(name)
+        if (failStop && name === 'l1') throw new Error('stop failed')
+      },
+    }))
+    const setup = Pool.setup({
+      instances: { l1: definition('l1'), l2: definition('l2') },
+      setup() {
+        throw new Error('setup failed')
+      },
+    })
+    const error = await setup(testProject(1).project).catch(
+      (error: unknown) => error,
+    )
+    if (failStop) {
+      expect(error).toBeInstanceOf(AggregateError)
+      expect((error as AggregateError).errors).toEqual([
+        new Error('setup failed'),
+        new Error('stop failed'),
+      ])
+    } else expect(error).toEqual(new Error('setup failed'))
+    expect(stopped.sort()).toEqual(['l1', 'l2'])
+  })
+
   test('starts one instance per worker and provides setup context', async () => {
     const started: number[] = []
     const stopped: number[] = []

--- a/src/vitest/Pool.ts
+++ b/src/vitest/Pool.ts
@@ -1,9 +1,13 @@
 import type { Instance } from '../Instance.js'
 import * as Pool from '../Pool.js'
 
-type StartedInstance<instance extends Instance> = Awaited<
-  ReturnType<Pool.Pool<number, instance>['start']>
->
+type StartedInstance<
+  definition extends Instance | ((poolId: number) => Instance),
+> = definition extends (poolId: number) => infer instance
+  ? StartedInstance<Extract<instance, Instance>>
+  : definition extends Instance
+    ? Awaited<ReturnType<Pool.Pool<number, definition>['start']>>
+    : never
 
 /** Returns the value provided for the current Vitest pool. */
 export function get<const value>(values: readonly value[]): value {
@@ -25,32 +29,87 @@ export function poolId(): number {
   return id
 }
 
-/** Creates Vitest global setup with one instance per worker. */
+/** Starts an isolated instance per worker, or per name and worker. */
+export function setup<
+  const instances extends Record<
+    string,
+    Instance | ((poolId: number) => Instance)
+  >,
+  project extends setup.Project = setup.Project,
+>(
+  parameters: setup.NamedParameters<instances, project>,
+): setup.ReturnType<project>
 export function setup<
   instance extends Instance = Instance,
   project extends setup.Project = setup.Project,
->(parameters: setup.Parameters<instance, project>): setup.ReturnType<project> {
+>(parameters: setup.Parameters<instance, project>): setup.ReturnType<project>
+export function setup<
+  const instances extends Record<
+    string,
+    Instance | ((poolId: number) => Instance)
+  >,
+  instance extends Instance = Instance,
+  project extends setup.Project = setup.Project,
+>(
+  parameters:
+    | setup.Parameters<instance, project>
+    | setup.NamedParameters<instances, project>,
+): setup.ReturnType<project> {
   return async (project) => {
     const { maxWorkers } = project.config
     if (!Number.isSafeInteger(maxWorkers) || maxWorkers < 1)
       throw new Error('Vitest maxWorkers must be a positive integer.')
 
-    const pool = Pool.define({
-      instance: parameters.instance,
-      limit: maxWorkers,
-    })
+    const definitions =
+      'instances' in parameters
+        ? parameters.instances
+        : { default: parameters.instance }
+    const pools = Object.entries(definitions).map(([name, instance]) => ({
+      name,
+      pool: Pool.define({ instance, limit: maxWorkers }),
+    }))
     const starts = Array.from({ length: maxWorkers }, (_, index) =>
-      pool.start(index + 1),
+      pools.map(
+        async ({ name, pool }) => [name, await pool.start(index + 1)] as const,
+      ),
     )
 
+    async function stop() {
+      const results = await Promise.allSettled(
+        pools.map(({ pool }) => pool.destroyAll()),
+      )
+      const errors = results.flatMap((result) =>
+        result.status === 'rejected' ? [result.reason] : [],
+      )
+      if (errors.length === 1) throw errors[0]
+      if (errors.length > 1)
+        throw new AggregateError(errors, 'Failed to destroy Vitest pools.')
+    }
+
     try {
-      const instances = await Promise.all(starts)
-      await parameters.setup(instances, project)
-      return () => pool.destroyAll()
+      const instances = await Promise.all(
+        starts.map((entries) => Promise.all(entries)),
+      )
+      if ('instances' in parameters)
+        await parameters.setup(
+          instances.map((entries) =>
+            Object.fromEntries(entries),
+          ) as setup.Instances<instances>[],
+          project,
+        )
+      else
+        await parameters.setup(
+          instances.map(
+            (entries) => entries[0]![1],
+          ) as StartedInstance<instance>[],
+          project,
+        )
+      return stop
     } catch (error) {
-      await Promise.allSettled(starts)
+      // A sibling may still start after Promise.all rejects.
+      await Promise.allSettled(starts.flat())
       try {
-        await pool.destroyAll()
+        await stop()
       } catch (destroyError) {
         throw new AggregateError(
           [error, destroyError],
@@ -63,6 +122,27 @@ export function setup<
 }
 
 export declare namespace setup {
+  /** Started instances for one worker, preserving each definition's endpoint types. */
+  export type Instances<
+    instances extends Record<string, Instance | ((poolId: number) => Instance)>,
+  > = {
+    [name in keyof instances]: StartedInstance<instances[name]>
+  }
+
+  /** Options for named eager pools with one instance per name and worker. */
+  export type NamedParameters<
+    instances extends Record<string, Instance | ((poolId: number) => Instance)>,
+    project extends Project = Project,
+  > = {
+    /** Definitions or worker-ID factories keyed by instance name. */
+    instances: instances
+    /** Receives worker-ordered records after every instance starts. */
+    setup(
+      instances: readonly Instances<instances>[],
+      project: project,
+    ): Promise<void> | void
+  }
+
   /** Options for setting up a Vitest worker pool. */
   export type Parameters<
     instance extends Instance = Instance,

--- a/src/vitest/Server.test-d.ts
+++ b/src/vitest/Server.test-d.ts
@@ -1,0 +1,49 @@
+import { Instance } from 'prool'
+import { Server } from 'prool/vitest'
+import { describe, expectTypeOf, test } from 'vitest'
+
+describe('setup', () => {
+  test('infers named contexts and worker factories', () => {
+    Server.setup({
+      instances: {
+        l1: Instance.anvil(),
+        l2: (id) => {
+          expectTypeOf(id).toEqualTypeOf<number>()
+          return Instance.anvil()
+        },
+      },
+      setup(contexts, project) {
+        expectTypeOf(contexts.l1).toEqualTypeOf<Server.Context>()
+        expectTypeOf(contexts.l2).toEqualTypeOf<Server.Context>()
+        expectTypeOf(project).toEqualTypeOf<Server.setup.Project>()
+        // @ts-expect-error Only configured names are available.
+        contexts.l3
+      },
+    })
+  })
+
+  test('rejects mixed single and named definitions', () => {
+    // @ts-expect-error Setup accepts either instance or instances.
+    Server.setup({
+      instance: Instance.anvil(),
+      instances: { l1: Instance.anvil() },
+      setup() {},
+    })
+  })
+})
+
+describe('get', () => {
+  test('preserves named controls and single contexts', () => {
+    expectTypeOf(
+      Server.get({ url: 'http://localhost:3000' }),
+    ).toEqualTypeOf<Server.Server>()
+    const servers = Server.get({
+      l1: { url: 'http://localhost:3000' },
+      l2: { url: 'http://localhost:4000' },
+    })
+    expectTypeOf(servers.l1).toEqualTypeOf<Server.Server>()
+    expectTypeOf(servers.l2).toEqualTypeOf<Server.Server>()
+    // @ts-expect-error Only configured names are available.
+    servers.l3
+  })
+})

--- a/src/vitest/Server.test.ts
+++ b/src/vitest/Server.test.ts
@@ -1,3 +1,4 @@
+import * as Http from 'node:http'
 import { Instance } from 'prool'
 import { Server } from 'prool/vitest'
 import { afterEach, describe, expect, expectTypeOf, test, vi } from 'vitest'
@@ -7,6 +8,106 @@ afterEach(() => {
 })
 
 describe('get', () => {
+  test('isolates named instances and workers over HTTP', async () => {
+    const definition = Instance.define(
+      (options: { name: string; worker: number }) => {
+        let requests = 0
+        const server = Http.createServer((_request, response) => {
+          response.end(JSON.stringify({ ...options, requests: ++requests }))
+        })
+        return {
+          host: '127.0.0.1',
+          name: options.name,
+          port: 0,
+          async start({ port }) {
+            await new Promise<void>((resolve) =>
+              server.listen(port, '127.0.0.1', resolve),
+            )
+          },
+          async stop() {
+            await new Promise<void>((resolve, reject) =>
+              server.close((error) => (error ? reject(error) : resolve())),
+            )
+          },
+        }
+      },
+    )
+    const { context, project } = testProject(2)
+    const setup = Server.setup({
+      instances: {
+        l1: (worker) => definition({ name: 'l1', worker }),
+        l2: (worker) => definition({ name: 'l2', worker }),
+      },
+      setup(servers, project) {
+        project.provide('servers', servers)
+      },
+    })
+    const teardown = await setup(project)
+    try {
+      const contexts = context.get('servers') as {
+        l1: Server.Context
+        l2: Server.Context
+      }
+      expect(contexts.l1.url).not.toBe(contexts.l2.url)
+      vi.stubEnv('VITEST_POOL_ID', '1')
+      const first = Server.get(contexts)
+      vi.stubEnv('VITEST_POOL_ID', '2')
+      const second = Server.get(contexts)
+
+      expect(
+        await Promise.all(
+          [first.l1, first.l2, second.l1, second.l2].map(async (server) =>
+            (await fetch(server.url)).json(),
+          ),
+        ),
+      ).toEqual([
+        { name: 'l1', worker: 1, requests: 1 },
+        { name: 'l2', worker: 1, requests: 1 },
+        { name: 'l1', worker: 2, requests: 1 },
+        { name: 'l2', worker: 2, requests: 1 },
+      ])
+      await first.l1.reset()
+      expect(await (await fetch(first.l1.url)).json()).toEqual({
+        name: 'l1',
+        worker: 1,
+        requests: 1,
+      })
+      expect(await (await fetch(first.l2.url)).json()).toEqual({
+        name: 'l2',
+        worker: 1,
+        requests: 2,
+      })
+      expect(await (await fetch(second.l1.url)).json()).toEqual({
+        name: 'l1',
+        worker: 2,
+        requests: 2,
+      })
+      await first.l2.restart()
+      expect(await (await fetch(first.l2.url)).json()).toEqual({
+        name: 'l2',
+        worker: 1,
+        requests: 3,
+      })
+      expect(await (await fetch(second.l2.url)).json()).toEqual({
+        name: 'l2',
+        worker: 2,
+        requests: 2,
+      })
+    } finally {
+      await teardown()
+    }
+  })
+
+  test('supports instance names that match context properties', () => {
+    vi.stubEnv('VITEST_POOL_ID', '2')
+    const servers = Server.get({
+      url: { url: 'http://localhost:3000/' },
+      default: { url: 'http://localhost:4000' },
+    })
+    expect(servers.url.url).toBe('http://localhost:3000/2')
+    expect(servers.default.url).toBe('http://localhost:4000/2')
+  })
+
   test('controls the current worker instance', async () => {
     vi.stubEnv('VITEST_POOL_ID', '2')
     const started: number[] = []
@@ -91,6 +192,66 @@ describe('get', () => {
 })
 
 describe('setup', () => {
+  test('cleans up every named server when setup fails', async () => {
+    const stopped: string[] = []
+    const definition = Instance.define((name: string) => ({
+      host: 'localhost',
+      name,
+      port: 3000,
+      async start() {},
+      async stop() {
+        stopped.push(name)
+      },
+    }))
+    const contexts: Server.Context[] = []
+    const setup = Server.setup({
+      instances: { l1: definition('l1'), l2: definition('l2') },
+      async setup(servers) {
+        contexts.push(...Object.values(servers))
+        for (const server of contexts) {
+          const response = await fetch(`${server.url}/1/start`, {
+            method: 'POST',
+          })
+          expect(response.status).toBe(200)
+          await response.text()
+        }
+        throw new Error('setup failed')
+      },
+    })
+    await expect(setup(testProject(1).project)).rejects.toThrowError(
+      'setup failed',
+    )
+    expect(stopped.sort()).toEqual(['l1', 'l2'])
+    for (const context of contexts)
+      await expect(fetch(`${context.url}/healthcheck`)).rejects.toThrow()
+  })
+
+  test('attempts every named teardown when one fails', async () => {
+    const stopped: string[] = []
+    const definition = Instance.define((name: string) => ({
+      host: 'localhost',
+      name,
+      port: 3000,
+      async start() {},
+      async stop() {
+        stopped.push(name)
+        if (name === 'l1') throw new Error('l1 stop failed')
+      },
+    }))
+    const setup = Server.setup({
+      instances: { l1: definition('l1'), l2: definition('l2') },
+      async setup(servers) {
+        for (const server of Object.values(servers))
+          await fetch(`${server.url}/1/start`, { method: 'POST' }).then(
+            (response) => response.text(),
+          )
+      },
+    })
+    const teardown = await setup(testProject(1).project)
+    await expect(teardown()).rejects.toThrowError('l1 stop failed')
+    expect(stopped.sort()).toEqual(['l1', 'l2'])
+  })
+
   test('limits instances to the worker count', async () => {
     const { context, project } = testProject(1)
     const setup = Server.setup({

--- a/src/vitest/Server.ts
+++ b/src/vitest/Server.ts
@@ -21,8 +21,20 @@ export type Server = {
   restart(options?: ControlOptions | undefined): Promise<void>
 }
 
-/** Returns the server URL and controls for the current Vitest pool. */
-export function get(context: Context): Server {
+/** Returns worker-scoped URLs and controls for one server or named servers. */
+export function get(context: Context): Server
+export function get<const contexts extends Record<string, Context>>(
+  context: contexts,
+): { [name in keyof contexts]: Server }
+export function get(
+  context: Context | Record<string, Context>,
+): Server | Record<string, Server> {
+  if (typeof context.url !== 'string')
+    return Object.fromEntries(
+      Object.entries(context as Record<string, Context>).map(
+        ([name, value]) => [name, get(value)],
+      ),
+    )
   const url = `${context.url.replace(/\/+$/, '')}/${Pool.poolId()}`
   return {
     url,
@@ -31,36 +43,82 @@ export function get(context: Context): Server {
   }
 }
 
-/** Creates Vitest global setup with a lazy keyed instance server. */
+/** Creates lazy keyed servers with an isolated instance per name and worker. */
+export function setup<
+  const instances extends Record<
+    string,
+    Instance | ((poolId: number) => Instance)
+  >,
+  project extends setup.Project = setup.Project,
+>(
+  parameters: setup.NamedParameters<instances, project>,
+): setup.ReturnType<project>
 export function setup<
   instance extends Instance = Instance,
   project extends setup.Project = setup.Project,
->(parameters: setup.Parameters<instance, project>): setup.ReturnType<project> {
+>(parameters: setup.Parameters<instance, project>): setup.ReturnType<project>
+export function setup<
+  const instances extends Record<
+    string,
+    Instance | ((poolId: number) => Instance)
+  >,
+  instance extends Instance = Instance,
+  project extends setup.Project = setup.Project,
+>(
+  parameters:
+    | setup.Parameters<instance, project>
+    | setup.NamedParameters<instances, project>,
+): setup.ReturnType<project> {
   return async (project) => {
     const { maxWorkers } = project.config
     if (!Number.isSafeInteger(maxWorkers) || maxWorkers < 1)
       throw new Error('Vitest maxWorkers must be a positive integer.')
 
-    const { setup: setup_, ...serverParameters } = parameters
-    const server = ProolServer.create({
-      ...serverParameters,
-      host: serverParameters.host ?? '127.0.0.1',
-      limit: maxWorkers,
-    })
-    await server.start()
+    const definitions =
+      'instances' in parameters
+        ? parameters.instances
+        : { default: parameters.instance }
+    const servers: ProolServer.CreateServerReturnType[] = []
+    const contexts: [string, Context][] = []
 
-    const address = server.address()!
-    const host = address.address.includes(':')
-      ? `[${address.address}]`
-      : address.address
-    const context = { url: `http://${host}:${address.port}` }
+    async function stop() {
+      const results = await Promise.allSettled(
+        servers.map((server) => server.stop()),
+      )
+      const errors = results.flatMap((result) =>
+        result.status === 'rejected' ? [result.reason] : [],
+      )
+      if (errors.length === 1) throw errors[0]
+      if (errors.length > 1)
+        throw new AggregateError(errors, 'Failed to stop Vitest servers.')
+    }
 
     try {
-      await setup_(context, project)
-      return () => server.stop()
+      for (const [name, instance] of Object.entries(definitions)) {
+        const server = ProolServer.create({
+          instance,
+          host: parameters.host ?? '127.0.0.1',
+          port: 'instances' in parameters ? 0 : parameters.port,
+          limit: maxWorkers,
+        })
+        await server.start()
+        servers.push(server)
+        const address = server.address()!
+        const host = address.address.includes(':')
+          ? `[${address.address}]`
+          : address.address
+        contexts.push([name, { url: `http://${host}:${address.port}` }])
+      }
+      if ('instances' in parameters)
+        await parameters.setup(
+          Object.fromEntries(contexts) as setup.Contexts<instances>,
+          project,
+        )
+      else await parameters.setup(contexts[0]![1], project)
+      return stop
     } catch (error) {
       try {
-        await server.stop()
+        await stop()
       } catch (stopError) {
         throw new AggregateError(
           [error, stopError],
@@ -73,6 +131,22 @@ export function setup<
 }
 
 export declare namespace setup {
+  /** Serializable server contexts keyed by instance name. */
+  export type Contexts<instances> = { [name in keyof instances]: Context }
+
+  /** Options for named lazy servers, each bound to an available port. */
+  export type NamedParameters<
+    instances extends Record<string, Instance | ((poolId: number) => Instance)>,
+    project extends Project = Project,
+  > = {
+    /** Definitions or worker-ID factories keyed by instance name. */
+    instances: instances
+    /** Host for every proxy server. Defaults to `127.0.0.1`. */
+    host?: string | undefined
+    /** Provides named serializable contexts after every proxy starts. */
+    setup(contexts: Contexts<instances>, project: project): Promise<void> | void
+  }
+
   /** Options for setting up a lazy Vitest instance server. */
   export type Parameters<
     instance extends Instance = Instance,

--- a/src/vitest/index.ts
+++ b/src/vitest/index.ts
@@ -1,2 +1,4 @@
+/** Eager single or named instances isolated by Vitest worker. */
 export * as Pool from './Pool.js'
+/** Lazy single or named proxies with worker-scoped lifecycle controls. */
 export * as Server from './Server.js'


### PR DESCRIPTION
Added named `instances` to Vitest `Server.setup` and `Pool.setup` for multiple isolated instances per worker, with independent lifecycle controls and cleanup. Preserved the single-instance API.
